### PR TITLE
Accept single-end sequencing and accept RNAseq only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@ mhc_hammer_output
 .DS_Store
 singularity*
 
+conf/*.config
+!conf/base.config
+!conf/hpc.config
+!conf/modules.config
+!conf/test.config
+
+assets/kmer_files
+assets/mhc_references

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You need to create a inventory file with the following columns:
 - purity - the purity of the tumour region. Can be left empty.
 - ploidy - the ploidy of the tumour region. Can be left empty.
 - normal_sample_name - when sequencing_type is `wxs` this is the matched germline WXS. When sequencing_type is `rnaseq` this is the matched RNAseq normal name. Can be left empty.
+- paired_end - either `paired` or `single`, depending on the sequencing type. Optional.
 
 The inventory should be a csv file and is input to the pipeline with the `--input` parameter. 
 

--- a/bin/check_samplesheet.R
+++ b/bin/check_samplesheet.R
@@ -9,11 +9,17 @@ parser$add_argument('--sample_sheet_path',  nargs=1,
 parser$add_argument('--validated_sample_sheet_path', nargs=1,
                     help="Path to save sample sheet",
                     required=TRUE)
+parser$add_argument('--run_hlahd', nargs='?',
+                    const=TRUE,
+                    default=TRUE,
+                    help="If true, predict HLA alleles from WXS germline sample",
+                    required=FALSE)
 
 args <- parser$parse_args()
 
 sample_sheet_path <- args$sample_sheet_path
 validated_sample_sheet_path <- args$validated_sample_sheet_path
+run_hlahd <- args$run_hlahd
 
 # Read in the sample sheet
 if(!file.exists(sample_sheet_path)){
@@ -97,7 +103,12 @@ if(missing_gl){
   missing_gl_patients <- unique(sample_sheet[!patient %in% patients_with_wxs_gl]$patient)
   msg <- paste0("The following patients are missing a germline WXS sample in the sample sheet:\n",
                 paste0(missing_gl_patients, collapse = "\n"), "\n")
-  stop(msg)
+  warning(msg)
+  if (run_hlahd) {
+    msg <- paste0("Cannot run HLAHD without a germline WXS, ",
+                  "provide path to HLA alleles in input inventory file.")
+    stop(msg)
+  }
 }
 
 # check every matched normal has a bam path

--- a/bin/make_cohort_mosdepth_table.R
+++ b/bin/make_cohort_mosdepth_table.R
@@ -74,7 +74,7 @@ if(nrow(rnaseq_novoalign_mosdepth_tables) > 0){
 
 # wxs novoalign
 cohort_wxs_novoalign_mosdepth_tables <- data.table()
-for(line_idx in 1:nrow(wxs_novoalign_mosdepth_tables)){
+for(line_idx in seq_len(nrow(wxs_novoalign_mosdepth_tables))){
   
   x <- fread(wxs_novoalign_mosdepth_tables[line_idx]$csv_path)
   setnames(x, c("allele", "start", "stop", "feature_name", "depth"))
@@ -84,9 +84,9 @@ for(line_idx in 1:nrow(wxs_novoalign_mosdepth_tables)){
   cohort_wxs_novoalign_mosdepth_tables <- rbindlist(list(cohort_wxs_novoalign_mosdepth_tables, x))
   
 }
+if (nrow(cohort_wxs_novoalign_mosdepth_tables) > 0) {
+  setnames(cohort_wxs_novoalign_mosdepth_tables, "stop", "end")
+  setcolorder(cohort_wxs_novoalign_mosdepth_tables, c("sample_name", "allele", "start", "end", "feature_name", "depth"))
+}
 
-setnames(cohort_wxs_novoalign_mosdepth_tables, "stop", "end")
-setcolorder(cohort_wxs_novoalign_mosdepth_tables, c("sample_name", "allele", "start", "end", "feature_name", "depth"))
 fwrite(cohort_wxs_novoalign_mosdepth_tables, "mosdepth_novoalign_wes_star.csv")
-
-

--- a/bin/make_hla_bams.sh
+++ b/bin/make_hla_bams.sh
@@ -6,6 +6,7 @@ max_mismatch=$3
 sample_id=$4
 seq=$5
 aligner=$6
+paired_end=$7
 
 echo "hla_bam=$hla_bam"
 echo "scripts_dir=$scripts_dir"
@@ -13,6 +14,7 @@ echo "max_mismatch=$max_mismatch"
 echo "sample_id=$sample_id"
 echo "seq=$seq"
 echo "aligner=$aligner"
+echo "paired_end=$paired_end"
 
 
 # Get patient alleles to loop through
@@ -51,7 +53,8 @@ for i in ${alleles}; do
     --bam_path "${sample_id}_${seq}_${aligner}.${i}.sorted.bam" \
     --max_mismatch "${max_mismatch}" \
     --allele "${i}" \
-    --sample_name "${sample_id}_${seq}_${aligner}"
+    --sample_name "${sample_id}_${seq}_${aligner}" \
+    --paired_end "$paired_end"
 
 
     # Step 6: Generate final allele-specific BAM if passed reads file is not empty

--- a/bin/quantify_mismatches.R
+++ b/bin/quantify_mismatches.R
@@ -15,8 +15,16 @@ parser$add_argument('--allele',  nargs=1,
 parser$add_argument('--sample_name',  nargs=1,
                     help='Sample name',
                     required=TRUE)
+parser$add_argument('--paired_end', nargs='?',
+                    const=TRUE,
+                    default=TRUE,
+                    help=paste0("Specify whether the sample is paired-end. ",
+                                "Include the argument (with or without a value) ",
+                                "for paired-end data. If omitted, single-end ",
+                                "data will be assumed."),
+                    required=FALSE)
 
-count.events <- function(BAMfile, n){
+count.events <- function(BAMfile, n, pairedEnd){
   x              <- scanBam(BAMfile, index = BAMfile, param=ScanBamParam(what = scanBamWhat(), tag = 'NM'))
   readIDs        <- x[[1]][['qname']]
   cigar          <- x[[1]][['cigar']]
@@ -24,7 +32,7 @@ count.events <- function(BAMfile, n){
   insertionCount <- sapply(cigar, FUN = function(boop) {return(length(grep(pattern = 'I', x = unlist(strsplit(boop, split = '')))))} )
   deletionCount  <- sapply(cigar, FUN = function(boop) {return(length(grep(pattern = 'D', x = unlist(strsplit(boop, split = '')))))} )
   indelTotals    <- sapply(cigar, FUN = function(boop) {
-    tmp <- unlist(strsplit( gsub("([0-9]+)","~\\1~",boop), "~" ))
+    tmp <- unlist(strsplit(gsub("([0-9]+)","~\\1~",boop), "~" ))
     Is  <- grep(pattern = 'I', x = tmp)
     Ds  <- grep(pattern = 'D', x = tmp)
     total <- sum(as.numeric(tmp[(Is-1)])) + sum(as.numeric(tmp[Ds-1]))
@@ -35,7 +43,9 @@ count.events <- function(BAMfile, n){
   names(eventCount) <- 1:length(eventCount)
   passed     <- eventCount[which(eventCount <= n)]
   y <- readIDs[as.numeric(names(passed))]
-  y <- names(table(y)[which(table(y) == 2)])
+  if (pairedEnd) {
+    y <- names(table(y)[which(table(y) == 2)])
+  }
   return(y)
 }
 
@@ -47,15 +57,21 @@ bam_path <- args$bam_path
 max_mismatch <- args$max_mismatch
 allele <- args$allele
 sample_name <- args$sample_name
+paired_end <- args$paired_end
+
+# Convert paired_end to logical if it's a string
+if (is.character(paired_end)) {
+  paired_end <- tolower(paired_end) == "true"
+}
 
 cat("bam_path=", bam_path, "\n")
 cat("allele=", allele, "\n")
 cat("sample_name=", sample_name, "\n")
 
 if(!file.exists(bam_path)){
-  stop("Bam doesnt exist: ", bam_path, "\n")
+  stop("Bam doesn't exist: ", bam_path, "\n")
 }
 
-passed_reads <- count.events(bam_path, n = max_mismatch)
+passed_reads <- count.events(bam_path, n = max_mismatch, pairedEnd = paired_end)
 write.table(passed_reads, file = paste0(sample_name, ".", allele,".passed_reads.txt"),
                   sep = '\t', quote = FALSE, row.names = FALSE, col.names = FALSE)

--- a/bin/splice_junction_tumour_normal_enrichment.R
+++ b/bin/splice_junction_tumour_normal_enrichment.R
@@ -47,11 +47,17 @@ normal_known_sjs <- fread(normal_known_sjs_path)
 tumour_sample_name <- unique(tumour_novel_sjs$sample_name)
 normal_sample_name <- unique(normal_novel_sjs$sample_name)
 
+if(!"intron_n_reads" %in% colnames(tumour_novel_sjs)) {
+  tumour_novel_sjs$intron_n_reads <- NA
+}
 tumour_novel_sjs <- tumour_novel_sjs[,c("allele", "gene", "start", "end", "n_unique_reads", "canonical_sj_read_count",
                                         "intron_n_reads", "novel_transcript_proportion", "total_read_count",
                                         "novel_sj_cat", "canonical_sj_names", "sj_type",
                                         "framshift", "premature_stop", "exon_intron_name")]
 
+if(!"intron_n_reads" %in% colnames(normal_novel_sjs)) {
+  normal_novel_sjs$intron_n_reads <- NA
+}
 normal_novel_sjs <- normal_novel_sjs[,c("allele", "gene", "start", "end", "n_unique_reads", "canonical_sj_read_count",
                                         "intron_n_reads", "novel_transcript_proportion", "total_read_count",
                                         "novel_sj_cat", "canonical_sj_names", "sj_type",

--- a/bin/star_second_pass.sh
+++ b/bin/star_second_pass.sh
@@ -11,8 +11,9 @@ original_genome_size=""
 fasta_file=""
 gtf_file=""
 star_overhang=""
+paired_end=""
 
-while getopts "f:t:s:j:b:r:l:a:g:o:" opt; do
+while getopts "f:t:s:j:b:r:l:a:g:p:o:" opt; do
     case "${opt}" in
         f)
             fq_prefix="${OPTARG}";
@@ -43,6 +44,9 @@ while getopts "f:t:s:j:b:r:l:a:g:o:" opt; do
             ;;     
         o)
             star_overhang="${OPTARG}";
+            ;;                         
+        p)
+            paired_end="${OPTARG}";
             ;;                                                             
         \?)
             echo -e "Error: Invalid option: -${OPTARG}\n" >&2
@@ -114,8 +118,15 @@ echo original_genome_size=$original_genome_size
 echo fasta_file=$fasta_file
 echo gtf_file=$gtf_file
 echo star_overhang=$star_overhang
+echo paired_end=$paired_end
 echo PWD=$PWD
 echo ""
+
+if [ "$paired_end" = "true" ]; then
+    read_files_in="$fq_prefix.1.fq.gz $fq_prefix.2.fq.gz"
+else
+    read_files_in="$fq_prefix.fq.gz"
+fi
 
 echo "Running STAR"
 set +e
@@ -123,7 +134,7 @@ set +e
     STAR \
     --runThreadN $task_cpus \
     --genomeDir $reference_dir \
-    --readFilesIn $fq_prefix".1.fq.gz" $fq_prefix".2.fq.gz" \
+    --readFilesIn $read_files_in \
     --readFilesCommand gunzip -c \
     --outSAMunmapped None \
     --outFilterType BySJout \
@@ -173,7 +184,7 @@ if [[ "$star_error_code" -eq 139 ]]; then
         STAR \
         --runThreadN $task_cpus \
         --genomeDir "star_genome_"$new_genome_length \
-        --readFilesIn $fq_prefix".1.fq.gz" $fq_prefix".2.fq.gz" \
+        --readFilesIn $read_files_in \
         --readFilesCommand gunzip -c \
         --outSAMunmapped None \
         --outFilterType BySJout \

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -68,7 +68,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/${meta.patient_id}/fqs" },
             mode: "${params.publish_dir_mode}",
-            pattern: '*.{1,2}.fq.gz',
+            pattern: '*.fq.gz',
             enabled: params.save_hla_fqs
         ]
     }

--- a/modules/local/samplesheet_check.nf
+++ b/modules/local/samplesheet_check.nf
@@ -17,7 +17,8 @@ process SAMPLESHEET_CHECK {
     """
     Rscript --vanilla ${baseDir}/bin/check_samplesheet.R \
         --sample_sheet_path ${samplesheet} \
-        --validated_sample_sheet_path samplesheet.valid.csv
+        --validated_sample_sheet_path samplesheet.valid.csv \
+        --run_hlahd ${params.run_hlahd}
     
     # Get R version and package versions
     R_VERSION=\$(Rscript -e "cat(as.character(getRversion()))")

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -174,6 +174,13 @@
             "description": "General parameters for how the pipeline will be run",
             "default": "",
             "properties": {
+                "run_preprocessing_only": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Run only the preprocessing part of the pipeline.",
+                    "hidden": true,
+                    "help_text": "Stop the pipeline after running preprocessing sub-workflow, consisting of input_check, library size calculation, and preparation of input files channel."
+                },
                 "run_bam_subsetting": {
                     "type": "boolean",
                     "default": true,
@@ -194,7 +201,7 @@
                 "run_hlahd": {
                     "type": "boolean",
                     "default": true,
-                    "description": "If inputting HLA alleles you can skip running HLA-HD by setting this parameter to false. You need to have an additional column in the input file with a column called "
+                    "description": "If inputting HLA alleles you can skip running HLA-HD by setting this parameter to false. You need to have an additional column in the input file and call it `hla_alleles_path`."
                 },
                 "hlahd_local_install": {
                     "type": "boolean",

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -135,11 +135,18 @@ workflow INPUT_CHECK {
 
 def create_bam_channels(LinkedHashMap row) {
     def meta = [:]
-    meta.patient_id     = row.patient
-    meta.sample_id      = row.sample_name
-    meta.sample_type    = row.sample_type
-    meta.seq            = row.sequencing_type
+    meta.patient_id          = row.patient
+    meta.sample_id           = row.sample_name
+    meta.sample_type         = row.sample_type
+    meta.seq                 = row.sequencing_type
     meta.normal_sample_name  = row.normal_sample_name
+    def paired_end           = row.paired_end
+    if (paired_end == null || paired_end.toString().trim().isEmpty()) {
+        meta.paired_end = true
+    } else {
+        paired_end = paired_end.toString().toLowerCase().trim()
+        meta.paired_end = !(paired_end in ["0", "false", "single", "single-end", "single end", "singleend", "s", "n", "no"])
+    }
 
     def bam_array = []
     if (!file(row.bam_path).exists()) {

--- a/test/data/mhc_hammer_test_inventory.csv
+++ b/test/data/mhc_hammer_test_inventory.csv
@@ -1,5 +1,5 @@
-patient,sample_name,sample_type,bam_path,sequencing_type,purity,ploidy,normal_sample_name,hla_alleles_path
-SIM001,SIM001_GL,normal,test/data/SIM_001_gl_genome.bam,wxs,,,,test/data/SIM001_hla_alleles.csv
-SIM001,SIM001_TUM,tumour,test/data/SIM_001_tumour_genome.bam,wxs,0.5,2,SIM001_GL,test/data/SIM001_hla_alleles.csv
-SIM001,SIM001_N01,normal,test/data/SIM_001_gl_transcriptome.bam,rna,,,,test/data/SIM001_hla_alleles.csv
-SIM001,SIM001_TUM,tumour,test/data/SIM_001_tumour_transcriptome.bam,rna,,,SIM001_N01,test/data/SIM001_hla_alleles.csv
+patient,sample_name,sample_type,bam_path,sequencing_type,purity,ploidy,normal_sample_name,hla_alleles_path,paired_end
+SIM001,SIM001_GL,normal,test/data/SIM_001_gl_genome.bam,wxs,,,,test/data/SIM001_hla_alleles.csv,paired
+SIM001,SIM001_TUM,tumour,test/data/SIM_001_tumour_genome.bam,wxs,0.5,2,SIM001_GL,test/data/SIM001_hla_alleles.csv,paired
+SIM001,SIM001_N01,normal,test/data/SIM_001_gl_transcriptome.bam,rna,,,,test/data/SIM001_hla_alleles.csv,paired
+SIM001,SIM001_TUM,tumour,test/data/SIM_001_tumour_transcriptome.bam,rna,,,SIM001_N01,test/data/SIM001_hla_alleles.csv,paired


### PR DESCRIPTION
These changes allow to run the pipeline with RNAseq data only (provided that the user gives HLA typing as input) and to use single-end sequencing data.
Although paired-end is more suitable to detect alternative splicing events and to analyse highly-polymorphic regions in general, it is worth being able to use this tool when the sequencing has already been performed and it is single-end.