### PR TITLE
Fix manual imgt version

### DIFF
--- a/scripts/convert_hla_dat.R
+++ b/scripts/convert_hla_dat.R
@@ -26,7 +26,23 @@ source(functions_file)
 ##### process hla dat #####
 
 cat("Reading in the hla.dat file\n")
-x <- readLines(path_to_hla_dat)
+
+# Check if the file is a ZIP archive - IMGT updated to .zip format recently
+if (grepl("\\.zip$", path_to_hla_dat)) {
+  
+  # Specify the name of the file inside ZIP
+  file_name_inside_zip <- "hla.dat"
+  
+  # Read the file from the ZIP archive
+  x <- readLines(unz(path_to_hla_dat, file_name_inside_zip))
+} else {
+  
+  # Read the file directly
+  x <- readLines(path_to_hla_dat)
+}
+
+# Print a success message
+cat("Successfully read the hla.dat file\n")
 
 # get the id lines
 id_lines <- grep('^ID', x)

--- a/scripts/create_mhc_hammer_references.R
+++ b/scripts/create_mhc_hammer_references.R
@@ -35,8 +35,34 @@ functions_file <- args$functions_file
 source(functions_file)
 
 cat("Getting genome fasta\n")
-gen_fasta_path <- paste0(imgt_dir, "/hla_gen.fasta")
-gen_fasta <- read.fasta(gen_fasta_path, forceDNAtolower = FALSE)
+gen_fasta_path <- list.files(imgt_dir, pattern = "hla_gen\\.fasta(\\.zip)?$", full.names = TRUE)
+
+# Check if a matching file was found
+if (length(gen_fasta_path) == 0) {
+  stop("No file matching the pattern 'hla_gen.fasta' or 'hla_gen.fasta.zip' found in the directory.")
+}
+
+# Check if a matching file was found
+if (length(gen_fasta_path) > 1) {
+  stop("More than one file matching the pattern 'hla_gen.fasta' or 'hla_gen.fasta.zip' found in the directory.")
+}
+
+
+# Determine if the file is zipped and read accordingly
+if (grepl("\\.zip$", gen_fasta_path)) {
+  
+  # Specify the name of the FASTA file inside ZIP
+  file_name_inside_zip <- "hla_gen.fasta"
+  
+  # Read the FASTA file from the ZIP archive
+  gen_fasta <- read.fasta(unz(gen_fasta_path, file_name_inside_zip), forceDNAtolower = FALSE)
+} else {
+ 
+  # Read the FASTA file directly
+  gen_fasta <- read.fasta(gen_fasta_path, forceDNAtolower = FALSE)
+}
+cat("Successfully read the genome FASTA file\n")
+
 allele_names <- NULL
 for(i in 1:length(gen_fasta)){allele_names = c(allele_names, attr(gen_fasta[[i]], "Annot"))}
 allele_names <- unname(sapply(allele_names, function(x) unlist(strsplit(x, " "))[2]))

--- a/scripts/make_fasta_file.R
+++ b/scripts/make_fasta_file.R
@@ -42,7 +42,15 @@ all_fasta <- c()
 for(f in c(gen_fasta_files, nuc_fasta_files)){
   f_path <- paste0(fasta_dir, "/", f)
   cat(f_path, "\n")
-  all_fasta <- c(all_fasta, read.fasta(f_path, forceDNAtolower = FALSE))
+
+  if(grepl("\\.zip$", f_path)){
+
+    file_name_inside_zip <- gsub("\\.zip$", "", basename(f_path))
+
+    all_fasta <- c(all_fasta, read.fasta(unz(f_path, file_name_inside_zip), forceDNAtolower = FALSE))
+  } else {
+    all_fasta <- c(all_fasta, read.fasta(f_path, forceDNAtolower = FALSE))
+  }
 }
 
 rev_all_fasta <- vector(mode = 'list', length = length(all_fasta))


### PR DESCRIPTION
IMGT repo updated hla.dat and hla_gen.fasta files to .zip. 

These changes mean these files are now read in correctly and users can correctly update the MHC-hammer references to their desired IMGT version